### PR TITLE
Fix misaligned event cards

### DIFF
--- a/website/templates/website/events.html
+++ b/website/templates/website/events.html
@@ -2,72 +2,51 @@
 {% load staticfiles %}
 {% block title %}ACE Events{% endblock %}
 {% block content %}
-    <section class="recent-posts gray-section large-section" style="background-image: url('{% static 'website/img/assets/absurdity.png'%}')">
+<section class="recent-posts gray-section large-section" style="background-image: url('{% static 'website/img/assets/absurdity.png'%}')">
+    <div class="container">
         <div class="container">
-            <div class="container">
-                <div class="row">
-                    <div class="col d-flex justify-content-center">
-                        <h2 class="section-title text-center title-divider" data-bigletter="R" data-aos="fade-up"
-                            data-aos-delay="100" data-aos-anchor-placement="top-bottom"
-                            data-aos-easing="ease-in-out" data-aos-duration="700">Recent Events</h2>
-                    </div>
-                </div>
-            </div>
-
-            <div class="container">
-                <div class="row blog-grid-row">
-                    {% for event in events  %}
-                    <div class="col-lg-4">
-                        <div class="blog-card-wrapper hover3d-wrapper" data-aos="fade-right" data-aos-delay="100"
-                        data-aos-anchor-placement="top-bottom"
-                        data-aos-easing="ease-in-out" data-aos-duration="600">
-                            <div class="card-content hover3d-child">
-                                <div class="card-blog-header">
-                                    <div class="img-wrapper d-flex align-items-center justify-content-center">
-                                        <a href="#">
-                                            <img src="{{ event.images.url }}" alt="" class="img-fluid img">
-                                            <div class="tag bg-color-purple">{{event.event_type}}</div>
-                                        </a>
-                                    </div>
-                                </div>
-                                <div class="card-blog-body">
-                                    <h5><a href="#">{{event.name}}</a></h5>
-                                    <p class="content">{{event.description}}<a href="#">[...]</a></p>
-                                    <div class="card-blog-footer d-flex justify-content-between align-items-end">
-                                        <p class="date d-flex align-items-end">
-                                            <i class="fas fa-calendar-alt"></i>
-                                            {{event.start_date}}
-                                        </p>
-                                        <p class="info d-flex align-items-end">
-                                        </p>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    {% endfor %}
-            </div>
-            <div class="d-flex justify-content-center"
-                 data-aos="fade-up"
-                 data-aos-delay="100"
-                 data-aos-anchor-placement="top-bottom"
-                 data-aos-easing="ease-in-out"
-                 data-aos-duration="800">
-                <div class="blog-nav d-flex">
-                    <div class="active">
-                        1
-                    </div>
-                    <div>
-                        2
-                    </div>
-                    <div>
-                        3
-                    </div>
-                    <div>
-                        <i class="fa fa-angle-right"></i>
-                    </div>
+            <div class="row">
+                <div class="col d-flex justify-content-center">
+                    <h2 class="section-title text-center title-divider" data-bigletter="R" data-aos="fade-up"
+                        data-aos-delay="100" data-aos-anchor-placement="top-bottom"
+                        data-aos-easing="ease-in-out" data-aos-duration="700">Recent Events</h2>
                 </div>
             </div>
         </div>
-    </section>
+        <div class="row blog-wrapper">
+            {% for event in events  %}
+            <div class="col-lg-4 d-flex align-items-stretch">
+                <div class="blog-card-wrapper hover3d-wrapper w-100" 
+                    data-aos="fade-right" 
+                    data-aos-delay="100"
+                     data-aos-anchor-placement="top-bottom"
+                     data-aos-easing="ease-in-out" data-aos-duration="600">
+                    <div class="card-content hover3d-child d-flex flex-column">
+                        <div class="card-blog-header">
+                            <div class="img-wrapper d-flex align-items-center justify-content-center">
+                                <a href="#">
+                                    <img src="{{ event.images.url }}" alt="" class="img-fluid img">
+                                    <div class="tag bg-color-purple">{{event.event_type}}</div>
+                                </a>
+                            </div>
+                        </div>
+                        <div class="card-blog-body d-flex flex-column h-100">
+                            <h5><a href="#">{{event.name}}</a></h5>
+                            <p class="content h-100">{{event.description}}<a href="#">[...]</a></p>
+                            <div class="card-blog-footer d-flex justify-content-between align-items-end">
+                                <p class="date d-flex align-items-end">
+                                   <i class="fas fa-calendar-alt"></i>
+                                    {{event.start_date}}
+                                </p>
+                                <p class="info d-flex align-items-end">
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+</section>
 {% endblock %}

--- a/website/templates/website/index.html
+++ b/website/templates/website/index.html
@@ -472,11 +472,13 @@
             </div>
             <div class="row blog-wrapper">
                 {% for event in events  %}
-                <div class="col-lg-4">
-                    <div class="blog-card-wrapper hover3d-wrapper" data-aos="fade-right" data-aos-delay="100"
+                <div class="col-lg-4 d-flex align-items-stretch">
+                    <div class="blog-card-wrapper hover3d-wrapper w-100" 
+                        data-aos="fade-right" 
+                        data-aos-delay="100"
                          data-aos-anchor-placement="top-bottom"
                          data-aos-easing="ease-in-out" data-aos-duration="600">
-                        <div class="card-content hover3d-child">
+                        <div class="card-content hover3d-child d-flex flex-column">
                             <div class="card-blog-header">
                                 <div class="img-wrapper d-flex align-items-center justify-content-center">
                                     <a href="#">
@@ -485,9 +487,9 @@
                                     </a>
                                 </div>
                             </div>
-                            <div class="card-blog-body">
+                            <div class="card-blog-body d-flex flex-column h-100">
                                 <h5><a href="#">{{event.name}}</a></h5>
-                                <p class="content">{{event.description}}<a href="#">[...]</a></p>
+                                <p class="content h-100">{{event.description}}<a href="#">[...]</a></p>
                                 <div class="card-blog-footer d-flex justify-content-between align-items-end">
                                     <p class="date d-flex align-items-end">
                                        <i class="fas fa-calendar-alt"></i>
@@ -538,4 +540,3 @@
         </div>
     </section>
 {% endblock %}
-


### PR DESCRIPTION
# Issue Description
This pull request fixes #2 where cards in the events page have uneven height and removes pagination numbers below the cards.

# Changes
Used flexbox and its differents properties as well as height to achieve the desired look that is responsive from mobile screens to desktops screens.

# Tests
All tests where performed using Windows 10 in the following browsers:
- Firefox - version 88.0.1
- Google Chrome - version 90.0.4430.212
- Edge - version 90.0.818.66

## Chrome
![chrome_C9FFNiHEVB](https://user-images.githubusercontent.com/38200521/119231965-d4dd2400-bb12-11eb-9c06-526f6d9be599.png)

## Firefox
![firefox_MmQHnu9wob](https://user-images.githubusercontent.com/38200521/119231971-d9a1d800-bb12-11eb-82fe-fc9eadd92056.png)

## Edge
![msedge_K5SUZ8j6Uc](https://user-images.githubusercontent.com/38200521/119231973-de668c00-bb12-11eb-8e36-a9ad73f065de.png)

